### PR TITLE
Fix: did:web unable to load character pages (404)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-sonasky-ref",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/changelog.tsx
+++ b/src/changelog.tsx
@@ -79,6 +79,13 @@ const changelogData = [
         date: dayjs(`2026-05-15`),
         version: '1.4.0', // Despite the amount of updates, it's still backwards compatible so old records still show correctly. Only a minor version update.
     },
+    {
+        changes: [
+            `Bugfix: Add additional resolution option for W3C community draft did:web method.`,
+        ],
+        date: dayjs(`2026-06-04`),
+        version: '1.4.1',
+    },
 ];
 
 // Get latest version by the highest semver version

--- a/src/helpers/getPds.ts
+++ b/src/helpers/getPds.ts
@@ -21,7 +21,9 @@ interface Service {
 
 export const getPds = async (did: string) => {
     try {
-        const url = `https://plc.directory/${did}`;
+        const url = did.startsWith('did:web:')
+            ? `https://${did.slice('did:web:'.length)}/.well-known/did.json`
+            : `https://plc.directory/${did}`;
         const response = await fetch(url);
         const data = (await response.json()) as PlcDirectoryResult;
         const pds = data.service[0].serviceEndpoint;


### PR DESCRIPTION
```diff
-        const url = `https://plc.directory/${did}`;
+        const url = did.startsWith('did:web:')
+            ? `https://${did.slice('did:web:'.length)}/.well-known/did.json`
+            : `https://plc.directory/${did}`;
         const response = await fetch(url);
         const data = (await response.json()) as PlcDirectoryResult;
         const pds = data.service[0].serviceEndpoint;
```

For users on the [W3C community draft](https://w3c-ccg.github.io/did-method-web/) `did:web` method for DIDs, pull the `.well-known/did.json` file rather than using plc directory.